### PR TITLE
fix: bump up vte + usbredir with fastfloat dependency

### DIFF
--- a/org.virt_manager.virt-manager.yaml
+++ b/org.virt_manager.virt-manager.yaml
@@ -395,12 +395,7 @@ modules:
             buildsystem: cmake-ninja
             config-opts:
               - -GNinja
-              - -DFETCHCONTENT_FULLY_DISCONNECTED:BOOL=ON
-              - -DSYSTEM_DOCTEST:BOOL=OFF
               - -DFASTFLOAT_TEST:BOOL=OFF
-              - -DFASTFLOAT_EXHAUSTIVE:BOOL=OFF 
-            cleanup:
-              - /include
             sources:
               - type: archive
                 url: https://github.com/fastfloat/fast_float/archive/refs/tags/v7.0.0.tar.gz

--- a/org.virt_manager.virt-manager.yaml
+++ b/org.virt_manager.virt-manager.yaml
@@ -309,8 +309,8 @@ modules:
               - --sbindir=/app/bin
             sources:
               - type: archive
-                url: https://spice-space.org/download/usbredir/usbredir-0.14.0.tar.xz
-                sha256: 924dfb5c78328fae45a4c93a01bc83bb72c1310abeed119109255627a8baa332
+                url: https://spice-space.org/download/usbredir/usbredir-0.15.0.tar.xz
+                sha256: 6dc2a380277688a068191245dac2ab7063a552999d8ac3ad8e841c10ff050961
                 x-checker-data:
                   type: anitya
                   project-id: 16012
@@ -377,8 +377,8 @@ modules:
           - -Dvapi=false
         sources:
           - type: archive
-            url: https://download.gnome.org/sources/vte/0.78/vte-0.78.2.tar.xz
-            sha256: 35d7bcde07356846b4a12881c8e016705b70a9004a9082285eee5834ccc49890
+            url: https://download.gnome.org/sources/vte/0.79/vte-0.79.0.tar.xz
+            sha256: 32e58453f892114ff49ed2f682a602f055d088a8a8e5bbcd7004e133ce00bd40
             x-checker-data:
               type: gnome
               name: vte
@@ -390,6 +390,13 @@ modules:
           - /libexec
           - /share/gir-1.0
           - /share/vala
+        modules:
+          - name: fast-float
+            buildsystem: cmake-ninja
+            sources:
+              - type: archive
+                url: https://github.com/fastfloat/fast_float/archive/refs/tags/v7.0.0.tar.gz
+                sha256: d2a08e722f461fe699ba61392cd29e6b23be013d0f56e50c7786d0954bffcb17
 
       - name: python3-requests
         buildsystem: simple

--- a/org.virt_manager.virt-manager.yaml
+++ b/org.virt_manager.virt-manager.yaml
@@ -391,12 +391,25 @@ modules:
           - /share/gir-1.0
           - /share/vala
         modules:
-          - name: fast-float
+          - name: fast_float
             buildsystem: cmake-ninja
+            config-opts:
+              - -GNinja
+              - -DFETCHCONTENT_FULLY_DISCONNECTED:BOOL=ON
+              - -DSYSTEM_DOCTEST:BOOL=OFF
+              - -DFASTFLOAT_TEST:BOOL=OFF
+              - -DFASTFLOAT_EXHAUSTIVE:BOOL=OFF 
+            cleanup:
+              - /include
             sources:
               - type: archive
                 url: https://github.com/fastfloat/fast_float/archive/refs/tags/v7.0.0.tar.gz
                 sha256: d2a08e722f461fe699ba61392cd29e6b23be013d0f56e50c7786d0954bffcb17
+                x-checker-data:
+                  type: anitya
+                  project-id: 214353
+                  stable-only: true
+                  url-template: https://github.com/fastfloat/fast_float/archive/refs/tags/v$version.tar.gz
 
       - name: python3-requests
         buildsystem: simple


### PR DESCRIPTION
Seems to boot up VMs just fine nothing broke so Im calling this good to go 
![image](https://github.com/user-attachments/assets/1334d68d-aa3b-4a97-a95a-269d8dc03343)
