### PR TITLE
feat: add build option to libvirt so that it can find QEMU UEFI binaries

### DIFF
--- a/org.virt_manager.virt-manager.yaml
+++ b/org.virt_manager.virt-manager.yaml
@@ -92,6 +92,7 @@ modules:
           - -Drpath=enabled
           - -Dqemu_user=qemu
           - -Dqemu_group=qemu
+          - -Dqemu_datadir=/app/lib/extensions/share/qemu
           - -Ddocs=enabled
           - -Dtests=disabled
           - -Dstorage_mpath=disabled


### PR DESCRIPTION
This directory needs to be on the QEMU driver configuration so that libvirt can find the UEFI firmware blobs so that we can actually run UEFI virtual machines. This should make it possible to do that ootb now!  

![image](https://github.com/user-attachments/assets/f4149179-fa02-4627-80d2-c6c20d73f2e0)

@travier friendly ping

Fixes: https://github.com/flathub/org.virt_manager.virt_manager.Extension.Qemu/issues/1