### PR TITLE
fix(user-session): make libvirt monitor patch more consistent

### DIFF
--- a/libvirt-use-monitor-in-xdg-runtime-dir.patch
+++ b/libvirt-use-monitor-in-xdg-runtime-dir.patch
@@ -35,10 +35,10 @@ index d36088ba98..1c57cd66ae 100644
 +    basename = g_file_get_basename (file);
 +    path = g_build_filename (g_get_user_runtime_dir (), basename, NULL);
 +
-+    if (g_mkdir (path, 0700) == 0) 
-+        monConfig->data.nix.path = g_strdup_printf("%s/monitor.sock", path);
-+    else
-+        monConfig->data.nix.path = g_strdup_printf("%s/monitor.sock", domainDir);
++    g_mkdir (path, 0700);
++    monConfig->data.nix.path = g_strdup_printf("%s/monitor.sock", path);
++    
++    
 +
      return 0;
  }


### PR DESCRIPTION

This seemingly makes starting up VMs more consistent on the User session. It used to sometimes _not_ work and you'd need to click the "Start" button multiple times before it actually started