### PR TITLE
 flathub: Only make update PRs for important deps & fix libssh

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "require-important-update": true
+}

--- a/org.virt_manager.virt-manager.yaml
+++ b/org.virt_manager.virt-manager.yaml
@@ -70,6 +70,7 @@ modules:
           project-id: 8183
           stable-only: true
           url-template: https://github.com/virt-manager/virt-manager/archive/v$version.tar.gz
+          is-main-source: true
       - type: patch
         path: 0001-Use-org.virt_manager.virt-manager-as-application-nam.patch
 
@@ -121,6 +122,7 @@ modules:
               project-id: 13830
               stable-only: true
               url-template: https://libvirt.org/sources/libvirt-$version.tar.xz
+              is-important: true
           - type: patch
             path: libvirt-use-monitor-in-xdg-runtime-dir.patch
         cleanup:
@@ -211,6 +213,7 @@ modules:
                   project-id: 1729
                   stable-only: true
                   url-template: https://www.libssh.org/files/$major.$minor/libssh-$version.tar.xz
+                  is-important: true
           - name: libssh2
             buildsystem: cmake-ninja
             config-opts:
@@ -225,6 +228,7 @@ modules:
                   project-id: 1730
                   stable-only: true
                   url-template: https://www.libssh2.org/download/libssh2-$version.tar.gz
+                  is-important: true
 
       - name: libvirt-glib
         buildsystem: meson
@@ -243,6 +247,7 @@ modules:
               project-id: 11560
               stable-only: true
               url-template: https://libvirt.org/sources/glib/libvirt-glib-$version.tar.xz
+              is-important: true
         cleanup:
           - /share/gtk-doc
         modules:
@@ -276,6 +281,7 @@ modules:
               project-id: 13829
               stable-only: true
               url-template: https://libvirt.org/sources/python/libvirt-python-$version.tar.gz
+              is-important: true
 
       - name: gtk-vnc
         buildsystem: meson
@@ -503,6 +509,7 @@ modules:
               project-id: 155460
               stable-only: true
               url-template: https://releases.pagure.org/libosinfo/libosinfo-$version.tar.xz
+              is-important: true
         cleanup:
           - /share/gtk-doc
           - /share/vala
@@ -521,6 +528,7 @@ modules:
                   project-id: 226784
                   stable-only: true
                   url-template: https://releases.pagure.org/libosinfo/osinfo-db-$version.tar.xz
+                  is-important: true
             modules:
               - name: osinfo-db-tools
                 buildsystem: meson
@@ -533,5 +541,6 @@ modules:
                       project-id: 226782
                       stable-only: true
                       url-template: https://releases.pagure.org/libosinfo/osinfo-db-tools-$version.tar.xz
+                      is-important: true
                 cleanup:
                   - '*'


### PR DESCRIPTION
Fix 'stable-only' for libssh & libssh2

---

flathub: Only make update PRs for important deps

Reduce the number of update PRs to only those that update one of the
important dependencies or the main source.

See: https://github.com/flathub-infra/flatpak-external-data-checker#selectively-submitting-prs
See: https://docs.flathub.org/docs/for-app-authors/external-data-checker#only-create-updates-for-important-modules
