### PR TITLE
Use libcap-ng module from runtime

### DIFF
--- a/org.virt_manager.virt-manager.yaml
+++ b/org.virt_manager.virt-manager.yaml
@@ -278,22 +278,6 @@ modules:
               is-important: true
         cleanup:
           - /share/gtk-doc
-        modules:
-          - name: libcap-ng
-            config-opts:
-              - --enable-static=no
-            sources:
-              - type: archive
-                url: https://github.com/stevegrubb/libcap-ng/archive/v0.9.tar.gz
-                sha256: d7463da4b50924a385e306f585bb05dbe58e212ba846f8593c3b2bd31c6cb46b
-                x-checker-data:
-                  type: anitya
-                  project-id: 1570
-                  stable-only: true
-                  url-template: https://github.com/stevegrubb/libcap-ng/archive/v$version.tar.gz
-            cleanup:
-              - /bin
-              - /share/aclocal
 
       - name: libvirt-python
         buildsystem: simple


### PR DESCRIPTION
The freedesktop runtime version 25.08 provides the **libcap-ng** module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

**Related manifest file:**

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/libcap-ng.bst

Fixes: https://github.com/flathub/org.virt_manager.virt-manager/issues/112